### PR TITLE
Upgrade decency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.pyc
+.cache
+.python-version
+.tox
+.venv
+build/
+twisted/plugins/dropin.cache
+txStatsD.egg-info/
+_trial_temp/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-Twisted==11.1.0
-carbon==0.9.9
-whisper==0.9.9
-mock==1.0
-psutil==0.4.1
-wsgiref==0.1.2
-zope.interface==3.8.0
+Twisted>=11.1.0,<=15.5.0
+carbon>=0.9.9,<=0.9.15
+whisper>=0.9.9,<=0.9.15
+mock>=1.0,<=1.3.0
+psutil>=2.0.0,<=3.4.2
+wsgiref>=0.1.2,<=0.9.15

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author="txStatsD Developers",
     url="https://launchpad.net/txstatsd",
     license="MIT",
-    install_requires=['Twisted==11.1.0'],
+    install_requires=['Twisted>=11.1.0,<=15.5.0'],
     packages=find_packages() + ["twisted.plugins"],
     scripts=glob("./bin/*"),
     long_description=long_description,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py{26,27}
+
+[testenv]
+whitelist_externals = ln
+    rm
+commands = - ln -s {envsitepackagesdir}/opt/graphite/lib/carbon
+    trial  txstatsd
+    rm carbon
+deps = carbon
+    whisper
+    psutil
+    mock
+    py26: Twisted==11.1.0
+    py27: Twisted==15.5.0

--- a/txstatsd/process.py
+++ b/txstatsd/process.py
@@ -110,19 +110,19 @@ class ProcessReport(object):
 
     def get_memory_and_cpu(self, prefix="proc"):
         """Report memory and CPU stats for C{process}."""
-        vsize, rss = self.process.get_memory_info()
-        result = {prefix + ".cpu.percent": self.process.get_cpu_percent(),
+        vsize, rss = self.process.memory_info()
+        result = {prefix + ".cpu.percent": self.process.cpu_percent(),
                   prefix + ".memory.percent":
-                    self.process.get_memory_percent(),
+                    self.process.memory_percent(),
                   prefix + ".memory.vsize": vsize,
                   prefix + ".memory.rss": rss}
-        if getattr(self.process, "get_num_threads", None) is not None:
-            result[prefix + ".threads"] = self.process.get_num_threads()
+        if getattr(self.process, "num_threads", None) is not None:
+            result[prefix + ".threads"] = self.process.num_threads()
         return result
 
     def get_cpu_counters(self, prefix="proc"):
         """Report memory and CPU counters for C{process}."""
-        utime, stime = self.process.get_cpu_times()
+        utime, stime = self.process.cpu_times()
         result = {prefix + ".cpu.user": utime,
                   prefix + ".cpu.system": stime}
         return result
@@ -130,9 +130,9 @@ class ProcessReport(object):
     def get_io_counters(self, prefix="proc.io"):
         """Report IO statistics for C{process}."""
         result = {}
-        if getattr(self.process, "get_io_counters", None) is not None:
+        if getattr(self.process, "io_counters", None) is not None:
             (read_count, write_count,
-             read_bytes, write_bytes) = self.process.get_io_counters()
+             read_bytes, write_bytes) = self.process.io_counters()
             result.update({
                 prefix + ".read.count": read_count,
                 prefix + ".write.count": write_count,
@@ -143,8 +143,8 @@ class ProcessReport(object):
     def get_net_stats(self, prefix="proc.net"):
         """Report active connection statistics for C{process}."""
         result = {}
-        if getattr(self.process, "get_connections", None) is not None:
-            for connection in self.process.get_connections():
+        if getattr(self.process, "connections", None) is not None:
+            for connection in self.process.connections():
                 fd, family, _type, laddr, raddr, status = connection
                 if _type == socket.SOCK_STREAM:
                     key = prefix + ".status.%s" % status.lower()

--- a/txstatsd/tests/test_process.py
+++ b/txstatsd/tests/test_process.py
@@ -181,15 +181,15 @@ class TestSystemPerformance(TestCase):
         the number of threads will not be included in the output.
         """
         process = psutil.Process(os.getpid())
-        vsize, rss = process.get_memory_info()
-        cpu_percent = process.get_cpu_percent()
-        memory_percent = process.get_memory_percent()
+        vsize, rss = process.memory_info()
+        cpu_percent = process.cpu_percent()
+        memory_percent = process.memory_percent()
 
         proc = mock.Mock()
-        proc.get_memory_info.return_value = (vsize, rss)
-        proc.get_cpu_percent.return_value = cpu_percent
-        proc.get_memory_percent.return_value = memory_percent
-        proc.get_num_threads = None
+        proc.memory_info.return_value = (vsize, rss)
+        proc.cpu_percent.return_value = cpu_percent
+        proc.memory_percent.return_value = memory_percent
+        proc.num_threads = None
         result = ProcessReport(process=proc).get_memory_and_cpu()
         self.assertEqual(cpu_percent, result["proc.cpu.percent"])
         self.assertEqual(vsize, result["proc.memory.vsize"])
@@ -202,12 +202,12 @@ class TestSystemPerformance(TestCase):
         Process cpu counters are collected through psutil.
         """
         process = psutil.Process(os.getpid())
-        utime, stime = process.get_cpu_times()
+        utime, stime = process.cpu_times()
 
         proc = mock.Mock()
-        proc.get_cpu_times.return_value = (utime, stime)
+        proc.cpu_times.return_value = (utime, stime)
         result = ProcessReport(process=proc).get_cpu_counters()
-        proc.get_cpu_times.assert_called_once_with()
+        proc.cpu_times.assert_called_once_with()
         self.assertEqual(utime, result["proc.cpu.user"])
         self.assertEqual(stime, result["proc.cpu.system"])
 
@@ -220,20 +220,20 @@ class TestSystemPerformance(TestCase):
 
         """
         process = psutil.Process(os.getpid())
-        vsize, rss = process.get_memory_info()
-        cpu_percent = process.get_cpu_percent()
-        memory_percent = process.get_memory_percent()
+        vsize, rss = process.memory_info()
+        cpu_percent = process.cpu_percent()
+        memory_percent = process.memory_percent()
 
         proc = mock.Mock()
-        proc.get_memory_info.return_value = (vsize, rss)
-        proc.get_cpu_percent.return_value = cpu_percent
-        proc.get_memory_percent.return_value = memory_percent
-        proc.get_num_threads.return_value = 1
+        proc.memory_info.return_value = (vsize, rss)
+        proc.cpu_percent.return_value = cpu_percent
+        proc.memory_percent.return_value = memory_percent
+        proc.num_threads.return_value = 1
         result = ProcessReport(process=proc).get_memory_and_cpu()
-        proc.get_memory_info.assert_called_once_with()
-        proc.get_cpu_percent.assert_called_once_with()
-        proc.get_memory_percent.assert_called_once_with()
-        proc.get_num_threads.assert_called_once_with()
+        proc.memory_info.assert_called_once_with()
+        proc.cpu_percent.assert_called_once_with()
+        proc.memory_percent.assert_called_once_with()
+        proc.num_threads.assert_called_once_with()
 
 
         self.assertEqual(cpu_percent, result["proc.cpu.percent"])
@@ -247,7 +247,7 @@ class TestSystemPerformance(TestCase):
         # If the version of psutil doesn't have the C{get_io_counters},
         # then io stats are not included in the output.
         proc = mock.Mock()
-        proc.get_io_counters = None
+        proc.io_counters = None
         result = ProcessReport(process=proc).get_io_counters()
         self.failIf("proc.io.read.count" in result)
         self.failIf("proc.io.write.count" in result)
@@ -264,9 +264,9 @@ class TestSystemPerformance(TestCase):
         io_counters = (10, 42, 125, 16)
 
         proc = mock.Mock()
-        proc.get_io_counters.return_value = io_counters
+        proc.io_counters.return_value = io_counters
         result = ProcessReport(process=proc).get_io_counters()
-        proc.get_io_counters.assert_called_once_with()
+        proc.io_counters.assert_called_once_with()
         self.assertEqual(10, result["proc.io.read.count"])
         self.assertEqual(42, result["proc.io.write.count"])
         self.assertEqual(125, result["proc.io.read.bytes"])
@@ -282,7 +282,7 @@ class TestSystemPerformance(TestCase):
         # If the version of psutil doesn't have the C{get_io_counters},
         # then io stats are not included in the output.
         proc = mock.Mock()
-        proc.get_connections = None
+        proc.connections = None
         result = ProcessReport(process=proc).get_net_stats()
         self.failIf("proc.net.status.established" in result)
 
@@ -305,9 +305,9 @@ class TestSystemPerformance(TestCase):
             ]
 
         proc = mock.Mock()
-        proc.get_connections.return_value = connections
+        proc.connections.return_value = connections
         result = ProcessReport(process=proc).get_net_stats()
-        proc.get_connections.assert_called_once_with()
+        proc.connections.assert_called_once_with()
         self.assertEqual(2, result["proc.net.status.established"])
         self.assertEqual(1, result["proc.net.status.closing"])
         self.assertEqual(1, result["proc.net.status.syn_sent"])


### PR DESCRIPTION
Major code change is for adaption to changes of the psutil interface.
First I started with an compat layer, but while the change is nearly already two years in the wild - I dropped the idea and broke therefore backward compatibility. 

Beside psutil, I did not force new versions, but specified ranges witch I tested to not suddenly interfere into already existing installations. 

You probably want to raise the version for it.